### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A Model Context Protocol (MCP) server that provides systematic thinking, mental models, and debugging approaches for enhanced problem-solving capabilities.
 
+<a href="https://glama.ai/mcp/servers/@ThinkFar/clear-thought-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ThinkFar/clear-thought-mcp/badge" alt="Clear Thought Server MCP server" />
+</a>
+
 ## Features
 
 ### Mental Models


### PR DESCRIPTION
This PR adds a badge for the [Clear Thought Server](https://glama.ai/mcp/servers/@ThinkFar/clear-thought-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@ThinkFar/clear-thought-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ThinkFar/clear-thought-mcp/badge" alt="Clear Thought Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a badge with a link to the Clear Thought MCP server page on glama.ai at the top of the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->